### PR TITLE
Header styling

### DIFF
--- a/components/Today.js
+++ b/components/Today.js
@@ -25,77 +25,33 @@ function Today({ today, latestMaxPullUps, latestAmrap, latestScapHang, testDayTo
   return (
     <>
       <Header
-        // TODO: Extract styles to localStyles object below
         containerStyle={{
-          // paddingHorizontal: "10%",
           borderBottomWidth: 0,
           borderBottomRightRadius: 35,
           backgroundColor: "rgba(255, 255, 255, .3)",
         }}
-
-        // placement={'left'}
-        // leftContainerStyle={{ width: 0 }}
-        // rightContainerStyle={{ width: 0 }}
-
-        centerContainerStyle={{ width: 250, }}
-
-        // centerComponent={
-        //   <Pressable type="outline"
-        //     style={{
-        //       flexDirection: "row",
-        //       alignItems: "center",
-        //     }}
-        //     onPress={() => dispatch({ type: 'DECREMENT' })}
-        // >
-
-        //     <TouchableOpacity
-        //       onPress={docsNavigate}
-        //       style={{ position: 'absolute', left: -70 }}>
-        //       <Icon name="description" color="white" />
-        //     </TouchableOpacity>
-        //     <TouchableOpacity onPress={playgroundNavigate}>
-        //       <Icon type="antdesign" name="rocket1" color="white" />
-        //     </TouchableOpacity>
-        //   </View>
-        // }
-
-        leftComponent={
-          <View>
-            <Icon name="return-up-back" type="ionicon" color="white" size={28} style={{
-              padding: 12,
-              position: 'fixed',
-              right: -11,
-              top: -2,
-            }} />
-          </View>
-
-        }
-        rightComponent={
-          <View style={{flex: 0}}>
-          </View>
-
-        }
-
         centerComponent={
-          <View>
-            <Pressable type="outline"
-              style={{
-                width: '100%',
-                display: "flex",
-                position: "relative",
-                flexDirection: "row",
-                alignItems: "center",
-                // justifyContent: "center",
-                // marginRight: 50,
-              }}
+          <View
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              marginTop: 5,
+            }}>
+            <Pressable
               onPress={() => dispatch({ type: 'DECREMENT' })}
-            >
-
+              style={{ position: 'absolute', left: -50, padding: 10}}>
+              <Icon name="chevron-left" color="white" />
+            </Pressable>
+            <Pressable
+              onPress={() => dispatch({ type: 'DECREMENT' })}
+              style={{
+                flexDirection: 'row',
+              }}
+              >
               <Text style={{
                 fontWeight: "600",
                 fontSize: 20,
                 paddingVertical: 12,
-
               }}>
                 Previous Workout
               </Text>

--- a/components/Today.js
+++ b/components/Today.js
@@ -27,68 +27,70 @@ function Today({ today, latestMaxPullUps, latestAmrap, latestScapHang, testDayTo
       <Header
         // TODO: Extract styles to localStyles object below
         containerStyle={{
-          paddingHorizontal: "10%",
+          // paddingHorizontal: "10%",
           borderBottomWidth: 0,
           borderBottomRightRadius: 35,
           backgroundColor: "rgba(255, 255, 255, .3)",
         }}
 
-        placement={'left'}
-        leftContainerStyle={{flex: 0, width: 0}}
-        rightContainerStyle={{flex: 0, width: 0}}
+        // placement={'left'}
+        // leftContainerStyle={{ width: 25 }}
+        // rightContainerStyle={{ width: 10 }}
 
-        centerContainerStyle={{paddingHorizontal: 0}}
+        centerContainerStyle={{ paddingHorizontal: 0 }}
         centerComponent={
           <Pressable type="outline"
             style={{
-              width: '60%',
+              width: '100%',
               flexDirection: "row",
               alignItems: "center",
+              justifyContent: "center",
+              marginRight: 50,
             }}
             onPress={() => dispatch({ type: 'DECREMENT' })}
           >
-            <Icon name="back-in-time" type="entypo" color="white" size={24} style={{
-              borderStyle: 'solid',
-              borderRadius: '100%',
-              borderWidth: 1,
-              borderColor: 'rgba(255, 255, 255, .5)',
+            <Icon name="return-up-back" type="ionicon" color="white" size={24} style={{
               padding: 12,
-              marginRight: 10,
             }} />
-            <Text style={{ fontWeight: "600", fontSize: 20}}>Previous Workout</Text>
+            <Text style={{
+              fontWeight: "600",
+              fontSize: 20
+            }}>
+              Previous Workout
+            </Text>
           </Pressable>
         }
       />
 
       {/* Wrapper (RED) should fill remainder of screen height at full width  */}
       <View style={localStyles.wrapper}>
-          <Text style={localStyles.title}>
-            Workout #{today}:
-          </Text>
-          <Divider style={{ width: '80%', marginBottom: 20 }} />
-            {
-              (() => {
-                switch (workout) {
-                  case "mtfTest":
-                    return <MtfTest mtf={latestMaxPullUps} style={localStyles.workoutStyles} />;
-                    // CURRENT Idea: Keep the buttons where they are and manipulate the appearance via styling
-                    // Another Idea: trigger state change of "completionProps" to newMtf, which specifies the prop values passed to the button
-                  case "amrapTest":
-                    return <AmrapTest tdt={testDayTotal} latestAmrap={latestAmrap} style={localStyles.workoutStyles} />;
-                  case "scapHang":
-                    return <ScapHang mtf={latestMaxPullUps} scapHang={latestScapHang} style={localStyles.workoutStyles} />;
-                  case "chinUps":
-                    return <ChinUps mtf={latestMaxPullUps} style={localStyles.workoutStyles} />
-                  case "commando":
-                    return <Commando mtf={latestMaxPullUps} style={localStyles.workoutStyles} />;
-                  case "initialTest":
-                    return <InitialTest mtf={latestMaxPullUps} latestAmrap={latestAmrap} today={today} style={localStyles.workoutStyles} />;
-                  default:
-                    return <Text>~~~ Hmmmmmm..... ~~~</Text>
-                };
-              })()
-            }
-        </View>
+        <Text style={localStyles.title}>
+          Workout #{today}:
+        </Text>
+        <Divider style={{ width: '80%', marginBottom: 20 }} />
+        {
+          (() => {
+            switch (workout) {
+              case "mtfTest":
+                return <MtfTest mtf={latestMaxPullUps} style={localStyles.workoutStyles} />;
+              // CURRENT Idea: Keep the buttons where they are and manipulate the appearance via styling
+              // Another Idea: trigger state change of "completionProps" to newMtf, which specifies the prop values passed to the button
+              case "amrapTest":
+                return <AmrapTest tdt={testDayTotal} latestAmrap={latestAmrap} style={localStyles.workoutStyles} />;
+              case "scapHang":
+                return <ScapHang mtf={latestMaxPullUps} scapHang={latestScapHang} style={localStyles.workoutStyles} />;
+              case "chinUps":
+                return <ChinUps mtf={latestMaxPullUps} style={localStyles.workoutStyles} />
+              case "commando":
+                return <Commando mtf={latestMaxPullUps} style={localStyles.workoutStyles} />;
+              case "initialTest":
+                return <InitialTest mtf={latestMaxPullUps} latestAmrap={latestAmrap} today={today} style={localStyles.workoutStyles} />;
+              default:
+                return <Text>~~~ Hmmmmmm..... ~~~</Text>
+            };
+          })()
+        }
+      </View>
       {/* </View> */}
     </>
   );

--- a/components/Today.js
+++ b/components/Today.js
@@ -34,31 +34,73 @@ function Today({ today, latestMaxPullUps, latestAmrap, latestScapHang, testDayTo
         }}
 
         // placement={'left'}
-        // leftContainerStyle={{ width: 25 }}
-        // rightContainerStyle={{ width: 10 }}
+        // leftContainerStyle={{ width: 0 }}
+        // rightContainerStyle={{ width: 0 }}
 
-        centerContainerStyle={{ paddingHorizontal: 0 }}
-        centerComponent={
-          <Pressable type="outline"
-            style={{
-              width: '100%',
-              flexDirection: "row",
-              alignItems: "center",
-              justifyContent: "center",
-              marginRight: 50,
-            }}
-            onPress={() => dispatch({ type: 'DECREMENT' })}
-          >
-            <Icon name="return-up-back" type="ionicon" color="white" size={24} style={{
+        centerContainerStyle={{ width: 250, }}
+
+        // centerComponent={
+        //   <Pressable type="outline"
+        //     style={{
+        //       flexDirection: "row",
+        //       alignItems: "center",
+        //     }}
+        //     onPress={() => dispatch({ type: 'DECREMENT' })}
+        // >
+
+        //     <TouchableOpacity
+        //       onPress={docsNavigate}
+        //       style={{ position: 'absolute', left: -70 }}>
+        //       <Icon name="description" color="white" />
+        //     </TouchableOpacity>
+        //     <TouchableOpacity onPress={playgroundNavigate}>
+        //       <Icon type="antdesign" name="rocket1" color="white" />
+        //     </TouchableOpacity>
+        //   </View>
+        // }
+
+        leftComponent={
+          <View>
+            <Icon name="return-up-back" type="ionicon" color="white" size={28} style={{
               padding: 12,
+              position: 'fixed',
+              right: -11,
+              top: -2,
             }} />
-            <Text style={{
-              fontWeight: "600",
-              fontSize: 20
-            }}>
-              Previous Workout
-            </Text>
-          </Pressable>
+          </View>
+
+        }
+        rightComponent={
+          <View style={{flex: 0}}>
+          </View>
+
+        }
+
+        centerComponent={
+          <View>
+            <Pressable type="outline"
+              style={{
+                width: '100%',
+                display: "flex",
+                position: "relative",
+                flexDirection: "row",
+                alignItems: "center",
+                // justifyContent: "center",
+                // marginRight: 50,
+              }}
+              onPress={() => dispatch({ type: 'DECREMENT' })}
+            >
+
+              <Text style={{
+                fontWeight: "600",
+                fontSize: 20,
+                paddingVertical: 12,
+
+              }}>
+                Previous Workout
+              </Text>
+            </Pressable>
+          </View>
         }
       />
 

--- a/components/Today.js
+++ b/components/Today.js
@@ -56,7 +56,6 @@ function Today({ today, latestMaxPullUps, latestAmrap, latestScapHang, testDayTo
               }}>
                 Previous Workout
               </Text>
-            {/* <View style={{height: 10, width: '100%'}}/> */}
             </Pressable>
           </View>
         }
@@ -91,7 +90,6 @@ function Today({ today, latestMaxPullUps, latestAmrap, latestScapHang, testDayTo
           })()
         }
       </View>
-      {/* </View> */}
     </>
   );
 }

--- a/components/Today.js
+++ b/components/Today.js
@@ -36,25 +36,27 @@ function Today({ today, latestMaxPullUps, latestAmrap, latestScapHang, testDayTo
               display: 'flex',
               flexDirection: 'row',
               marginTop: 5,
+              alignItems: 'center',
             }}>
             <Pressable
               onPress={() => dispatch({ type: 'DECREMENT' })}
-              style={{ position: 'absolute', left: -50, padding: 10}}>
+              style={{
+                position: 'absolute',
+                left: -50,
+                padding: 11
+              }}>
               <Icon name="chevron-left" color="white" />
             </Pressable>
             <Pressable
-              onPress={() => dispatch({ type: 'DECREMENT' })}
-              style={{
-                flexDirection: 'row',
-              }}
-              >
+              onPress={() => dispatch({ type: 'DECREMENT' })}>
               <Text style={{
                 fontWeight: "600",
                 fontSize: 20,
-                paddingVertical: 12,
+                paddingVertical: 11,
               }}>
                 Previous Workout
               </Text>
+            {/* <View style={{height: 10, width: '100%'}}/> */}
             </Pressable>
           </View>
         }

--- a/components/workouts/InitialTest.js
+++ b/components/workouts/InitialTest.js
@@ -39,7 +39,6 @@ export default ({ style, mtf, latestAmrap, today }) => {
           <Text style={style.text}>
             Do pull-ups for AMRAP(i) within a 5-min period:
             {`\n`}– Breaks are allowed, but the timer must not stop.
-            {`\n`}– Try to beat {tdt} reps, your total pull-ups from Day 1.
           </Text>
           <Input
             initialValue={latestAmrap}


### PR DESCRIPTION
Changes 'back' icon to a left chevron, simplifies the code and styling for the header / back button, and centers the text without the icon pushing it to the right.
![IMG_9994](https://github.com/aenyeart/22days/assets/65784446/744727b6-7736-4dce-8ba5-50f5538879ed)
